### PR TITLE
Windows support for watch script

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,8 +24,8 @@
     "format:scss": "prettier --parser scss --write 'src/sass/**/*.scss'",
     "format:ts": "eslint --ext .ts --fix 'src/**/*.ts'",
     "watch": "run-p watch:*",
-    "watch:sass": "onchange --initial --kill 'src/sass/**/*.scss' -- npm run build:dev",
-    "watch:ts": "onchange --initial --kill 'src/**/*.ts' -- rollup --config rollup.config.js"
+    "watch:sass": "onchange --initial --kill \"src/sass/**/*.scss\" -- npm run build:dev",
+    "watch:ts": "onchange --initial --kill \"src/**/*.ts\" -- rollup --config rollup.config.js"
   },
   "devDependencies": {
     "@rollup/plugin-alias": "^3.1.2",


### PR DESCRIPTION
As noted on [the onchange package](https://www.npmjs.com/package/onchange) and tested by me on a Windows 10 machine, in order to use the watch scripts it's needed to use double quotes.

Note: I haven't tested it on a OSX or Linux environment if this change still works, but on Windows it works fine now.